### PR TITLE
Refine criteria for which reference/secondary scenes qualify for processing

### DIFF
--- a/landsat/cloudformation.yml
+++ b/landsat/cloudformation.yml
@@ -53,12 +53,7 @@ Resources:
       FilterPolicyScope: MessageBody
       FilterPolicy: |
         {
-          "landsat_product_id": [
-            {"prefix": "LC08_L1"},
-            {"prefix": "LC09_L1"},
-            {"prefix": "LO08_L1"},
-            {"prefix": "LO09_L1"}
-          ]
+          "s3_location": [{"prefix": "s3://usgs-landsat/collection02/level-1/standard/oli-tirs/"}]
         }
 
   Lambda:

--- a/landsat/src/main.py
+++ b/landsat/src/main.py
@@ -47,15 +47,17 @@ def _search_date(date_string: str) -> datetime:
 
 
 def _qualifies_for_processing(item: pystac.item.Item, max_cloud_cover: int = MAX_CLOUD_COVER_PERCENT) -> bool:
-    return item.collection_id == 'landsat-c2l1' and \
-           'OLI' in item.properties['instruments'] and \
-           item.properties['landsat:collection_category'] in ['T1', 'T2'] and \
-           item.properties['eo:cloud_cover'] < max_cloud_cover and \
-           item.properties['view:off_nadir'] == 0 and \
-           item.properties['landsat:wrs_path'] + item.properties['landsat:wrs_row'] in LANDSAT_TILES_TO_PROCESS
+    return (
+        item.collection_id == 'landsat-c2l1'
+        and 'OLI' in item.properties['instruments']
+        and item.properties['landsat:collection_category'] in ['T1', 'T2']
+        and item.properties['landsat:wrs_path'] + item.properties['landsat:wrs_row'] in LANDSAT_TILES_TO_PROCESS
+        and item.properties['eo:cloud_cover'] < max_cloud_cover
+        and item.properties['view:off_nadir'] == 0
+    )
 
 
-def _check_scene(scene: str,  max_cloud_cover: int = MAX_CLOUD_COVER_PERCENT) -> None:
+def _check_scene(scene: str, max_cloud_cover: int = MAX_CLOUD_COVER_PERCENT) -> None:
     collection = LANDSAT_CATALOG.get_collection(LANDSAT_COLLECTION)
     item = collection.get_item(scene)
     assert item is not None

--- a/landsat/src/main.py
+++ b/landsat/src/main.py
@@ -58,6 +58,7 @@ def _qualifies_for_processing(item: pystac.item.Item, max_cloud_cover: int = MAX
 def _check_scene(scene: str,  max_cloud_cover: int = MAX_CLOUD_COVER_PERCENT) -> None:
     collection = LANDSAT_CATALOG.get_collection(LANDSAT_COLLECTION)
     item = collection.get_item(scene)
+    assert item is not None
     assert _qualifies_for_processing(item, max_cloud_cover)
 
 


### PR DESCRIPTION
This moves the business logic of which scenes qualify for processing away from the SNS filter, since we'll need to apply the same business logic when checking for secondary scenes. The filter now only restricts to collection 02, level 1 products with the OLI/TRS sensor.

`_qualifies_for_processing()` does post-stac-search filtering of scenes, and allows us to use the same function to validate the  reference scene and any secondary scenes. This may make searching for secondary scenes somewhat less performant because we're using a broader STAC query, but the business logic is complex enough that I don't want to write it in two places in two different formats.