### PR TITLE
add dead letter queue as an offramp for messages that cannot be processed

### DIFF
--- a/landsat/cloudformation.yml
+++ b/landsat/cloudformation.yml
@@ -21,11 +21,19 @@ Parameters:
 
 Resources:
 
+  DeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      MessageRetentionPeriod: 1209600
+
   Queue:
     Type: AWS::SQS::Queue
     Properties:
       MessageRetentionPeriod: 1209600
       VisibilityTimeout: 300
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt DeadLetterQueue.Arn
+        maxReceiveCount: 2
 
   QueuePolicy:
     Type: AWS::SQS::QueuePolicy


### PR DESCRIPTION
See the example at https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sqs-queue.html#aws-resource-sqs-queue--examples--Amazon_SQS_Queue_with_a_Dead-Letter_Queue

Discussion of dead letter queues:
- https://docs.aws.amazon.com/prescriptive-guidance/latest/lambda-event-filtering-partial-batch-responses-for-sqs/best-practices-partial-batch-responses.html
- https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html