### PR TITLE
fix environment variable name mismatch

### DIFF
--- a/landsat/src/main.py
+++ b/landsat/src/main.py
@@ -32,7 +32,7 @@ HYP3 = sdk.HyP3(
 )
 
 log = logging.getLogger()
-log.setLevel(os.environ.get('LAMBDA_LOGGING_LEVEL', 'INFO'))
+log.setLevel(os.environ.get('LOGGING_LEVEL', 'INFO'))
 
 
 def _qualifies_for_processing(item: pystac.item.Item, max_cloud_cover: int = MAX_CLOUD_COVER_PERCENT) -> bool:


### PR DESCRIPTION
The cloudformation parameter is LambdaLoggingLevel, but the environment variable is names LOGGING_LEVEL in the lambda parameters at https://github.com/ASFHyP3/its-live-monitoring/blob/develop/landsat/cloudformation.yml#L79