### PR TITLE
Fix cloud cover requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - The `landsat:cloud_cover_land` property instead of `eo:cloud_cover` will be used to determine if a scene qualifies for processing
+- Scenes with unknown cloud cover (unreported or a value < 0) will be disqualified for processing
+- The max cloud cover percentage is now an inclusive bound, so only scenes with *more* (`>`) cloud cover will be disqualified 
 
 ## [0.0.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - HyP3 jobs will now be submitted with the `publish_bucket` job parameter set
 - The reason a scene disqualifies for processing will now be logged
 
+### Fixed
+- The `landsat:cloud_cover_land` property instead of `eo:cloud_cover` will be used to determine if a scene qualifies for processing
+
 ## [0.0.3]
 
 ### Changed

--- a/landsat/src/main.py
+++ b/landsat/src/main.py
@@ -54,7 +54,11 @@ def _qualifies_for_processing(
         log.log(log_level, f'{item.id} disqualifies for processing because it is not from a tile containing land-ice')
         return False
 
-    if item.properties['eo:cloud_cover'] >= max_cloud_cover:
+    if item.properties.get('landsat:cloud_cover_land', -1) < 0:
+        log.log(log_level, f'{item.id} disqualifies for processing because cloud coverage is unknown')
+        return False
+
+    if item.properties['landsat:cloud_cover_land'] > max_cloud_cover:
         log.log(log_level, f'{item.id} disqualifies for processing because it has too much cloud cover')
         return False
 

--- a/tests/landsat/test_main.py
+++ b/tests/landsat/test_main.py
@@ -46,6 +46,10 @@ def test_qualifies_for_processing():
     assert not main._qualifies_for_processing(item)
 
     item = get_mock_pystac_item()
+    del item.properties['landsat:cloud_cover_land']
+    assert not main._qualifies_for_processing(item)
+
+    item = get_mock_pystac_item()
     item.properties['landsat:cloud_cover_land'] = -1
     assert not main._qualifies_for_processing(item)
 

--- a/tests/landsat/test_main.py
+++ b/tests/landsat/test_main.py
@@ -11,7 +11,7 @@ def get_mock_pystac_item() -> unittest.mock.NonCallableMagicMock:
         'landsat:collection_category': 'T1',
         'landsat:wrs_path': '001',
         'landsat:wrs_row': '005',
-        'eo:cloud_cover': 50,
+        'landsat:cloud_cover_land': 50,
         'view:off_nadir': 0,
     }
     return item
@@ -46,15 +46,27 @@ def test_qualifies_for_processing():
     assert not main._qualifies_for_processing(item)
 
     item = get_mock_pystac_item()
-    item.properties['eo:cloud_cover'] = 59
-    assert main._qualifies_for_processing(item)
-
-    item = get_mock_pystac_item()
-    item.properties['eo:cloud_cover'] = 60
+    item.properties['landsat:cloud_cover_land'] = -1
     assert not main._qualifies_for_processing(item)
 
     item = get_mock_pystac_item()
-    item.properties['eo:cloud_cover'] = 61
+    item.properties['landsat:cloud_cover_land'] = 0
+    assert main._qualifies_for_processing(item)
+
+    item = get_mock_pystac_item()
+    item.properties['landsat:cloud_cover_land'] = 1
+    assert main._qualifies_for_processing(item)
+
+    item = get_mock_pystac_item()
+    item.properties['landsat:cloud_cover_land'] = main.MAX_CLOUD_COVER_PERCENT - 1
+    assert main._qualifies_for_processing(item)
+
+    item = get_mock_pystac_item()
+    item.properties['landsat:cloud_cover_land'] = main.MAX_CLOUD_COVER_PERCENT
+    assert main._qualifies_for_processing(item)
+
+    item = get_mock_pystac_item()
+    item.properties['landsat:cloud_cover_land'] = main.MAX_CLOUD_COVER_PERCENT + 1
     assert not main._qualifies_for_processing(item)
 
     item = get_mock_pystac_item()


### PR DESCRIPTION
Currently, our most common error is a missing `eo:cloud_cover` property in the STAC item.

From close inspection, it looks like we should be using `landsat:cloud_cover_land`:
* This matches what ITS_LIVE was doing previously better: https://github.com/nasa-jpl/its_live_production/blob/main/src/tools/missingpairstools/find_all_USGS_Collection2_imagepairs_for_jsoncatalogs.py#L266
* `eo:cloud_cover` appears to be missing for items where the cloud % was not calculated (`CLOUD_COVER = -1` in the product metadata), but the corrosponding `landsat:cloud_cover_land` does appear to exists with a value of -1 in these cases.

--- 

TODOs:
- [x] determine how to handle scenes when cloud cover was not calculated (value of -1). Previously, the scenes would be used as there is only a simple `<=` comparison being used and the -1 values aren't handled specially:
      https://github.com/nasa-jpl/its_live_production/blob/main/src/tools/missingpairstools/find_all_USGS_Collection2_imagepairs_for_jsoncatalogs.py#L266