### PR TITLE
Use tools-bot MatterMost account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.3.0]
+
+### Added
+- A CLI wrapper for `status_messages.py` so that it can more easily be run locally.
+
+### Fixed
+- Status messages can now be posted to mattermost with a bot account.
+
 ## [0.2.0]
 
 ### Added

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -146,4 +146,5 @@ Resources:
         QueueURL: !Ref DeadLetterQueue
         QueueName: !GetAtt DeadLetterQueue.QueueName
         MattermostPAT: !Ref MattermostPAT
+        LambdaLoggingLevel: !Ref LambdaLoggingLevel
       TemplateURL: status-messages/cloudformation.yml

--- a/landsat/src/main.py
+++ b/landsat/src/main.py
@@ -31,7 +31,7 @@ HYP3 = sdk.HyP3(
     password=EARTHDATA_PASSWORD,
 )
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 log.setLevel(os.environ.get('LOGGING_LEVEL', 'INFO'))
 
 
@@ -253,10 +253,11 @@ def main() -> None:
     parser.add_argument('-v', '--verbose', action='store_true', help='Turn on verbose logging')
     args = parser.parse_args()
 
-    level = logging.DEBUG if args.verbose else logging.INFO
-    logging.basicConfig(stream=sys.stdout, format='%(asctime)s - %(levelname)s - %(message)s', level=level)
-    log.debug(' '.join(sys.argv))
+    logging.basicConfig(stream=sys.stdout, format='%(asctime)s - %(levelname)s - %(message)s', level=logging.INFO)
+    if args.verbose:
+        log.setLevel(logging.DEBUG)
 
+    log.debug(' '.join(sys.argv))
     _ = process_scene(args.reference, timedelta(days=args.max_pair_separation), args.max_cloud_cover, args.submit)
 
 

--- a/status-messages/cloudformation.yml
+++ b/status-messages/cloudformation.yml
@@ -12,6 +12,13 @@ Parameters:
     Type: String
     NoEcho: true
 
+  LambdaLoggingLevel:
+    Type: String
+    Default: INFO
+    AllowedValues:
+      - INFO
+      - DEBUG
+
 Resources:
   LogGroup:
     Type: AWS::Logs::LogGroup
@@ -53,6 +60,7 @@ Resources:
         Variables:
           MATTERMOST_PAT: !Ref MattermostPAT
           QUEUE_URL: !Ref QueueURL
+          LOGGING_LEVEL: !Ref LambdaLoggingLevel
       Code: src/
       Handler: status_messages.lambda_handler
       Role: !GetAtt Role.Arn

--- a/status-messages/src/status_messages.py
+++ b/status-messages/src/status_messages.py
@@ -1,6 +1,9 @@
 """Lambda function to trigger Mattermost updates for Dead Letter Queue."""
 
+import argparse
+import logging
 import os
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -14,6 +17,8 @@ MATTERMOST_PAT = os.environ['MATTERMOST_PAT']
 # You can find the ID for a channel by looking in the channel info
 MATTERMOST_CHANNEL_ID = 'mmffdcqsafdg8xyr747scyuqnw'  # ~measures-its_live
 
+log = logging.getLogger(__name__)
+log.setLevel(os.environ.get('LOGGING_LEVEL', 'INFO'))
 
 def get_queue_count() -> str:
     """Retrieve the message count of the Dead Letter Queue.
@@ -41,7 +46,7 @@ def lambda_handler(event: dict, context: dict) -> None:
     """
     mattermost = Driver({'url': 'chat.asf.alaska.edu', 'token': MATTERMOST_PAT, 'scheme': 'https', 'port': 443})
     response = mattermost.login()
-    print(response)
+    log.debug(response)
 
     dead_letter_queue_count = int(get_queue_count())
 
@@ -56,10 +61,30 @@ def lambda_handler(event: dict, context: dict) -> None:
         f'{dead_letter_queue_count} entries on {datetime.now(tz=timezone.utc).isoformat()}'
     )
 
+    log.info(f'Posting: "{mattermost_message}" to {MATTERMOST_CHANNEL_ID}')
     response = mattermost.posts.create_post(
         options={
             'channel_id': MATTERMOST_CHANNEL_ID,
             'message': mattermost_message,
         }
     )
-    print(response)
+    log.debug(response)
+
+
+def main() -> None:
+    """Command Line wrapper around `lambda_handler`."""
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('-v', '--verbose', action='store_true', help='Turn on verbose logging')
+    args = parser.parse_args()
+
+    logging.basicConfig(stream=sys.stdout, format='%(asctime)s - %(levelname)s - %(message)s', level=logging.INFO)
+
+    if args.verbose:
+        log.setLevel(logging.DEBUG)
+
+    log.debug(' '.join(sys.argv))
+    lambda_handler({}, {})
+
+
+if __name__ == '__main__':
+    main()

--- a/status-messages/src/status_messages.py
+++ b/status-messages/src/status_messages.py
@@ -20,6 +20,7 @@ MATTERMOST_CHANNEL_ID = 'mmffdcqsafdg8xyr747scyuqnw'  # ~measures-its_live
 log = logging.getLogger(__name__)
 log.setLevel(os.environ.get('LOGGING_LEVEL', 'INFO'))
 
+
 def get_queue_count() -> str:
     """Retrieve the message count of the Dead Letter Queue.
 

--- a/status-messages/src/status_messages.py
+++ b/status-messages/src/status_messages.py
@@ -8,9 +8,11 @@ import boto3
 from mattermostdriver import Driver
 
 
-CHANNEL = 'measures-its_live'
 QUEUE_URL = os.environ['QUEUE_URL']
 MATTERMOST_PAT = os.environ['MATTERMOST_PAT']
+
+# You can find the ID for a channel by looking in the channel info
+MATTERMOST_CHANNEL_ID = 'mmffdcqsafdg8xyr747scyuqnw'  # ~measures-its_live
 
 
 def get_queue_count() -> str:
@@ -41,7 +43,6 @@ def lambda_handler(event: dict, context: dict) -> None:
     response = mattermost.login()
     print(response)
 
-    channel_info = mattermost.channels.get_channel_by_name_and_team_name('asf', CHANNEL)
     dead_letter_queue_count = int(get_queue_count())
 
     queue_name = Path(QUEUE_URL).name
@@ -54,9 +55,10 @@ def lambda_handler(event: dict, context: dict) -> None:
         f'{status_emoji} Dead Letter Queue Count for `{queue_name}` has '
         f'{dead_letter_queue_count} entries on {datetime.now(tz=timezone.utc).isoformat()}'
     )
+
     response = mattermost.posts.create_post(
         options={
-            'channel_id': channel_info['id'],
+            'channel_id': MATTERMOST_CHANNEL_ID,
             'message': mattermost_message,
         }
     )


### PR DESCRIPTION
Bot users cannot look up the channel ID so we'll need to provide it directly. You can find the channel id by looking at the channel info:
![image](https://github.com/ASFHyP3/its-live-monitoring/assets/7882693/6a13afb3-54dc-43c8-9069-a90e34e7eaf1)


I also wanted to run this locally to test it, so I've setup a `main()` function and logging.