### PR TITLE
Fix off-nadir handling for Landsat

### DIFF
--- a/landsat/src/main.py
+++ b/landsat/src/main.py
@@ -95,7 +95,7 @@ def get_landsat_pairs_for_reference_scene(
         query=[
             f'landsat:wrs_path={reference.properties["landsat:wrs_path"]}',
             f'landsat:wrs_row={reference.properties["landsat:wrs_row"]}',
-            f'view:off_nadir={reference.properties["view:off_nadir"]}',
+            'view:off_nadir>0' if reference.properties['view:off_nadir'] > 0 else 'view:off_nadir=0',
         ],
         datetime=[reference.datetime - max_pair_separation, reference.datetime - timedelta(seconds=1)],
     )

--- a/landsat/src/main.py
+++ b/landsat/src/main.py
@@ -139,11 +139,7 @@ def deduplicate_hyp3_pairs(pairs: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
         user_id=EARTHDATA_USERNAME,
     )
 
-    df = pd.DataFrame(
-        [[*job.job_parameters['granules'], *[job.job_id, job.status_code]] for job in jobs],
-        columns=['reference', 'secondary', 'job_id', 'status_code'],
-    )
-    df = df[df.status_code == 'SUCCEEDED']
+    df = pd.DataFrame([job.job_parameters['granules'] for job in jobs], columns=['reference', 'secondary'])
     df = df.set_index(['reference', 'secondary'])
     pairs = pairs.set_index(['reference', 'secondary'])
 

--- a/landsat/src/main.py
+++ b/landsat/src/main.py
@@ -102,6 +102,7 @@ def get_landsat_pairs_for_reference_scene(
 
     items = [item for page in results.pages() for item in page if _qualifies_for_processing(item, max_cloud_cover)]
 
+    log.debug(f'Found {len(items)} secondary scenes for {reference.id}')
     if len(items) == 0:
         return gpd.GeoDataFrame()
 


### PR DESCRIPTION
Also, this PR:
* logs the number of items found when querying for secondary pairs
* undoes undesired changes to deduplication
