### PR TITLE
Ensure S2 reference scene is in Google Cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.0]
 
 ### Added
-- Support for Sentinel-2
+- Support for processing Sentinel-2 SNS messages and submitting jobs to hyp3-its-live has been added
+
+### Changed
+- To manage any lag between Sentinel-2 messages being published in AWS and scenes being available in Google Cloud, which is where hyp3-autorift pulls scenes from, the message failure handling has been changed:
+  - The visibility timeout (time between attempts) has been extended from 5 minutes to 8 hours
+  - Processing messages will be attempted 3 times before being driven to the dead letter queue
 
 ## [0.4.0]
 

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -43,10 +43,10 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       MessageRetentionPeriod: 1209600
-      VisibilityTimeout: 300
+      VisibilityTimeout: 28800
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt DeadLetterQueue.Arn
-        maxReceiveCount: 2
+        maxReceiveCount: 3
 
   QueuePolicy:
     Type: AWS::SQS::QueuePolicy
@@ -60,7 +60,7 @@ Resources:
             Action: sqs:SendMessage
             Resource: !GetAtt Queue.Arn
             Condition:
-              ArnEquals: 
+              ArnEquals:
                 aws:SourceArn: [!Ref LandsatTopicArn, !Ref Sentinel2TopicArn]
       Queues:
         - !Ref Queue

--- a/its_live_monitoring/src/main.py
+++ b/its_live_monitoring/src/main.py
@@ -21,6 +21,7 @@ from sentinel2 import (
     get_sentinel2_pairs_for_reference_scene,
     get_sentinel2_stac_item,
     qualifies_for_sentinel2_processing,
+    raise_for_missing_in_google_cloud
 )
 
 
@@ -107,6 +108,9 @@ def process_scene(
     if scene.startswith('S2'):
         reference = get_sentinel2_stac_item(f'{scene}.SAFE')
         if qualifies_for_sentinel2_processing(reference, max_cloud_cover, logging.INFO):
+            # hyp3-its-live will pull scenes from Google Cloud; ensure the new scene is there before processing
+            # Note: Time between attempts is controlled by they SQS VisibilityTimout
+            _ = raise_for_missing_in_google_cloud(scene)
             pairs = get_sentinel2_pairs_for_reference_scene(reference, max_pair_separation, max_cloud_cover)
 
     else:

--- a/its_live_monitoring/src/main.py
+++ b/its_live_monitoring/src/main.py
@@ -119,14 +119,14 @@ def process_scene(
 
     log.info(f'Found {len(pairs)} pairs for {scene}')
     with pd.option_context('display.max_rows', None, 'display.max_columns', None, 'display.width', None):
-        log.debug(pairs.loc[:, ['reference', 'secondary']])
+        log.debug(pairs.sort_values(by=['secondary'], ascending=False).loc[:, ['reference', 'secondary']])
 
     if len(pairs) > 0:
         pairs = deduplicate_hyp3_pairs(pairs)
 
         log.info(f'Deduplicated pairs; {len(pairs)} remaining')
         with pd.option_context('display.max_rows', None, 'display.max_columns', None, 'display.width', None):
-            log.debug(pairs.loc[:, ['reference', 'secondary']])
+            log.debug(pairs.sort_values(by=['secondary'], ascending=False).loc[:, ['reference', 'secondary']])
 
     jobs = sdk.Batch()
     if submit:

--- a/its_live_monitoring/src/main.py
+++ b/its_live_monitoring/src/main.py
@@ -21,7 +21,7 @@ from sentinel2 import (
     get_sentinel2_pairs_for_reference_scene,
     get_sentinel2_stac_item,
     qualifies_for_sentinel2_processing,
-    raise_for_missing_in_google_cloud
+    raise_for_missing_in_google_cloud,
 )
 
 

--- a/its_live_monitoring/src/sentinel2.py
+++ b/its_live_monitoring/src/sentinel2.py
@@ -10,6 +10,7 @@ import geopandas as gpd
 import pandas as pd
 import pystac
 import pystac_client
+import requests
 
 from constants import MAX_CLOUD_COVER_PERCENT, MAX_PAIR_SEPARATION_IN_DAYS
 
@@ -22,6 +23,15 @@ SENTINEL2_TILES_TO_PROCESS = json.loads((Path(__file__).parent / 'sentinel2_tile
 
 log = logging.getLogger('its_live_monitoring')
 log.setLevel(os.environ.get('LOGGING_LEVEL', 'INFO'))
+
+
+def raise_for_missing_in_google_cloud(scene_name):
+    root_url = 'https://storage.googleapis.com/gcp-public-data-sentinel-2/tiles'
+    tile = f'{scene_name[39:41]}/{scene_name[41:42]}/{scene_name[42:44]}'
+
+    manifest_url = f'{root_url}/{tile}/{scene_name}.SAFE/manifest.safe'
+    response = requests.head(manifest_url)
+    response.raise_for_status()
 
 
 def get_sentinel2_stac_item(scene: str) -> pystac.Item:  # noqa: D103

--- a/its_live_monitoring/src/sentinel2.py
+++ b/its_live_monitoring/src/sentinel2.py
@@ -25,7 +25,7 @@ log = logging.getLogger('its_live_monitoring')
 log.setLevel(os.environ.get('LOGGING_LEVEL', 'INFO'))
 
 
-def raise_for_missing_in_google_cloud(scene_name):
+def raise_for_missing_in_google_cloud(scene_name: str) -> None:  # noqa: D103
     root_url = 'https://storage.googleapis.com/gcp-public-data-sentinel-2/tiles'
     tile = f'{scene_name[39:41]}/{scene_name[41:42]}/{scene_name[42:44]}'
 

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -3,3 +3,4 @@
 cfn-lint
 ruff
 pytest
+responses

--- a/requirements-landsat.txt
+++ b/requirements-landsat.txt
@@ -2,3 +2,4 @@ geopandas==0.14.3
 hyp3-sdk==6.1.0
 pandas==2.2.1
 pystac-client==0.7.6
+requests==2.31.0


### PR DESCRIPTION
This PR: 
*  adds a function that checks for a reference scene's `manifest.safe` in Google Cloud because hyp3-autorift is currently pulling scenes from Google
* spreads attempts to reprocess the scene across a 24-hour window to account for any lag between availability on S3 and in Google Cloud. 

Note: I'm not set on the number of attempts or time between attempts; this "feels right" to me but I'd like to hear any thoughts or alternative proposals. 

Notably, This does affect Landsat processing where the current drive policies seem to be working well -- this will cause the time between attempts to go from 5 minutes to 8 hours, but I think that's an acceptable trade-off for handling Sentinel-2. 


### Details:
If the scene doesn't exist (HTTP error on the manifest.safe HEAD request), it will throw an HTTPError.

There are three modes for processing an SQS message:
1. SUCCESS: Scene does qualify for processing; jobs submitted if they haven't been already
2. SUCCESS: Scene doesn't qualify for processing; no jobs submitted
3. FAILED: Any exception raised during processing.

raising does (3) causing a later attempt; returning True/False from `qualifies_for_processing` selects between (1)/(2) and removes the message from the queue. 


### References:
* SQS VisibiltyTimeout: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sqs-queue.html#cfn-sqs-queue-visibilitytimeout
* SQS RedrivePolicy: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sqs-queue.html#cfn-sqs-queue-redrivepolicy
* Using DeadLetter Queues: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html
