### PR TITLE
Try two stage deploy for EU subscription

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -51,17 +51,30 @@ runs:
           --template-file cloudformation.yml \
           --s3-bucket=${{ inputs.CF_TEMPLATE_BUCKET }} \
           --output-template-file packaged.yml
-        
+
         aws cloudformation deploy \
           --template-file packaged.yml \
           --stack-name=${{ inputs.STACK_NAME }} \
           --capabilities CAPABILITY_IAM \
           --parameter-overrides \
             LandsatTopicArn=${{ inputs.LANDSAT_TOPIC_ARN }} \
-            Sentinel2TopicArn=${{ inputs.SENTINEL2_TOPIC_ARN }} \
             Hyp3Api=${{ inputs.HYP3_API }} \
             LambdaLoggingLevel=${{ inputs.LAMBDA_LOGGING_LEVEL }} \
             EarthdataUsername=${{ inputs.EARTHDATA_USERNAME }} \
             EarthdataPassword=${{ inputs.EARTHDATA_PASSWORD }} \
             PublishBucket=${{ inputs.PUBLISH_BUCKET }} \
             MattermostPAT=${{ inputs.MATTERMOST_PAT }}
+
+        export ITS_LIVE_MONITORING_QUEUE_ARN=$( \
+          aws cloudformation describe-stacks \
+          --query "Stacks[?StackName=='${{ inputs.STACK_NAME }}'][].Outputs[?OutputKey=='ItsLiveMonitoringQueueArn'].OutputValue" \
+          --output text \
+        )
+
+        aws cloudformation deploy \
+            --region=eu-west-1 \
+            --stack-name=${{ inputs.STACK_NAME }} \
+            --s3-bucket=${{ inputs.CF_TEMPLATE_BUCKET }} \
+            --parameter-overrides \
+              Sentinel2TopicArn=${{ inputs.SENTINEL2_TOPIC_ARN }} \
+              ItsLiveMonitoringQueueArn=${ITS_LIVE_MONITORING_QUEUE_ARN}

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -23,7 +23,7 @@ jobs:
           EARTHDATA_PASSWORD: ${{ secrets.EARTHDATA_PASSWORD }}
           CF_TEMPLATE_BUCKET: cf-templates-3o5lnspmwmzg-us-west-2
           LANDSAT_TOPIC_ARN: arn:aws:sns:us-west-2:986442313181:its-live-notify-landsat-test
-          SENTINEL2_TOPIC_ARN: arn:aws:sns:us-west-2:986442313181:its-live-notify-sentinel2-test
+          SENTINEL2_TOPIC_ARN: arn:aws:sns:eu-west-1:986442313181:its-live-notify-sentinel2-test
           HYP3_API: https://hyp3-its-live.asf.alaska.edu
           LAMBDA_LOGGING_LEVEL: INFO
           PUBLISH_BUCKET: its-live-data-test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 export PYTHONPATH = ${PWD}/its_live_monitoring/src
 LANDSAT_TOPIC_ARN ?= arn:aws:sns:us-west-2:986442313181:its-live-notify-landsat-test
-SENTINEL2_TOPIC_ARN ?= arn:aws:sns:us-west-2:986442313181:its-live-notify-sentinel2-test
+SENTINEL2_TOPIC_ARN ?= arn:aws:sns:eu-west-1:986442313181:its-live-notify-sentinel2-test
 
 install:
 	python -m pip install --upgrade pip && \

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -33,7 +33,6 @@ Parameters:
     NoEcho: true
 
 Resources:
-
   DeadLetterQueue:
     Type: AWS::SQS::Queue
     Properties:
@@ -76,18 +75,6 @@ Resources:
         {
           "landsat_product_id": [{"suffix": "_T1"}, {"suffix": "_T2"}],
           "s3_location": [{"prefix": "s3://usgs-landsat/collection02/level-1/standard/oli-tirs/"}]
-        }
-
-  Sentinel2Subscription:
-    Type: AWS::SNS::Subscription
-    Properties:
-      TopicArn: !Ref Sentinel2TopicArn
-      Protocol: sqs
-      Endpoint: !GetAtt Queue.Arn
-      FilterPolicyScope: MessageBody
-      FilterPolicy: |
-        {
-          "name": [{"prefix": "S2A_MSIL1C_"}, {"prefix": "S2B_MSIL1C_"}]
         }
 
   Lambda:
@@ -163,3 +150,8 @@ Resources:
         MattermostPAT: !Ref MattermostPAT
         LambdaLoggingLevel: !Ref LambdaLoggingLevel
       TemplateURL: status-messages/cloudformation.yml
+
+Outputs:
+  ItsLiveMonitoringQueueArn:
+    Description: "The ARN for its-live-monitoring's SQS queue"
+    Value: !GetAtt Queue.Arn

--- a/its_live_monitoring/cloudformation-subscribe-in-eu.yml
+++ b/its_live_monitoring/cloudformation-subscribe-in-eu.yml
@@ -1,0 +1,19 @@
+Parameters:
+  Sentinel2TopicArn:
+    Type: String
+
+  ItsLiveMonitoringQueueArn:
+    Type: String
+
+Resources:
+  Sentinel2Subscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      TopicArn: !Ref Sentinel2TopicArn
+      Protocol: sqs
+      Endpoint: !Ref ItsLiveMonitoringQueueArn
+      FilterPolicyScope: MessageBody
+      FilterPolicy: |
+        {
+          "name": [{"prefix": "S2A_MSIL1C_"}, {"prefix": "S2B_MSIL1C_"}]
+        }


### PR DESCRIPTION
#75 failed to deploy and release because of an invalid TopicArn -- the subscription must be in the same region as the SNS topic, but it can (supposedly) feed SQSs in any region. See:
https://github.com/sinergise/Sentinel2ProductIngestor/issues/2

This separates the Sentinel2 subscription into its own stack, which is deployed after the monitoring stack.