### PR TITLE
Updates for v0.5.1 release

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -58,6 +58,7 @@ runs:
           --capabilities CAPABILITY_IAM \
           --parameter-overrides \
             LandsatTopicArn=${{ inputs.LANDSAT_TOPIC_ARN }} \
+            Sentinel2TopicArn=${{ inputs.SENTINEL2_TOPIC_ARN }} \
             Hyp3Api=${{ inputs.HYP3_API }} \
             LambdaLoggingLevel=${{ inputs.LAMBDA_LOGGING_LEVEL }} \
             EarthdataUsername=${{ inputs.EARTHDATA_USERNAME }} \

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -28,10 +28,3 @@ jobs:
           LAMBDA_LOGGING_LEVEL: INFO
           PUBLISH_BUCKET: its-live-data
           MATTERMOST_PAT: ${{ secrets.MATTERMOST_PAT }}
-
-
-  call-bump-version-workflow:
-    needs: deploy
-    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.11.0
-    secrets:
-      USER_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -1,0 +1,13 @@
+name: Tag New Version
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  call-bump-version-workflow:
+    needs: deploy
+    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.11.0
+    secrets:
+      USER_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1]
+
+### Fixed
+- Sentinel-2 search geometry now uses a small central square within a tile instead of a tile's bbox to avoid finding images from neighboring tiles.
+- its-live-monitoring now deploys the Sentinel-2 SNS subscription to the `eu-west-1` region since subscriptions are required to be in the same regions as the SNS Topic.
+
 ## [0.5.0]
+
+**NOTE:** Failed to deploy.
 
 ### Added
 - Support for processing Sentinel-2 SNS messages and submitting jobs to hyp3-its-live has been added

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ landsat-integration:
 
 sentinel2-integration:
 	export AWS_PAGER='' && \
-	$(foreach file, $(wildcard tests/integration/sentinel2*.json), aws sns publish --profile saml-pub --topic-arn ${SENTINEL2_TOPIC_ARN} --message file://${file} --output json;)
+	$(foreach file, $(wildcard tests/integration/sentinel2*.json), aws sns publish --region eu-west-1 --profile saml-pub --topic-arn ${SENTINEL2_TOPIC_ARN} --message file://${file} --output json;)
 
 integration: landsat-integration sentinel2-integration
 


### PR DESCRIPTION
The PR:
* will always tag a new version on a merge to main instead of requiring a successful deploy
* Adds a changelog entry for the v0.5.1 release and notes v0.5.0 failed to deploy
* Updates the Makefile to specify submitting Sentinel-2 integration test messages using the `eu-west-1` AWS region