### PR TITLE
Fix tag-version.yml

### DIFF
--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   call-bump-version-workflow:
-    needs: deploy
     uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.11.0
     secrets:
       USER_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}


### PR DESCRIPTION
The tag version workflow was moved out of the prod deployment workflow in #82 but the "needs" was accidentally left, causing this workflow to fail.
https://github.com/ASFHyP3/its-live-monitoring/actions/runs/9103048834

For a comparison, see the equivalent in the HyP3 SDK:
https://github.com/ASFHyP3/hyp3-sdk/blob/develop/.github/workflows/tag-version.yml