### PR TITLE
Refactor data coverage check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.2]
 
 ### Added
-- data_coverage > Max_DATA_PERCENTAGE condition in the qualifies_for_sentinel2_processing function.
+- Sentinel-2 will now be disqualified from processing if they do not have enough data coverage.
 
 ## [0.5.1]
 

--- a/its_live_monitoring/src/constants.py
+++ b/its_live_monitoring/src/constants.py
@@ -1,5 +1,0 @@
-"""Constants that are shared between multiple files."""
-
-MAX_PAIR_SEPARATION_IN_DAYS = 544
-MAX_CLOUD_COVER_PERCENT = 60
-MIN_DATA_COVER_PERCENT = 70

--- a/its_live_monitoring/src/landsat.py
+++ b/its_live_monitoring/src/landsat.py
@@ -11,14 +11,15 @@ import pandas as pd
 import pystac
 import pystac_client
 
-from constants import MAX_CLOUD_COVER_PERCENT, MAX_PAIR_SEPARATION_IN_DAYS
-
 
 LANDSAT_CATALOG_API = 'https://landsatlook.usgs.gov/stac-server'
 LANDSAT_CATALOG = pystac_client.Client.open(LANDSAT_CATALOG_API)
 LANDSAT_COLLECTION_NAME = 'landsat-c2l1'
 LANDSAT_COLLECTION = LANDSAT_CATALOG.get_collection(LANDSAT_COLLECTION_NAME)
 LANDSAT_TILES_TO_PROCESS = json.loads((Path(__file__).parent / 'landsat_tiles_to_process.json').read_text())
+
+LANDSAT_MAX_PAIR_SEPARATION_IN_DAYS = 544
+LANDSAT_MAX_CLOUD_COVER_PERCENT = 60
 
 log = logging.getLogger('its_live_monitoring')
 log.setLevel(os.environ.get('LOGGING_LEVEL', 'INFO'))
@@ -35,7 +36,7 @@ def get_landsat_stac_item(scene: str) -> pystac.Item:  # noqa: D103
 
 
 def qualifies_for_landsat_processing(
-    item: pystac.item.Item, max_cloud_cover: int = MAX_CLOUD_COVER_PERCENT, log_level: int = logging.DEBUG
+    item: pystac.item.Item, max_cloud_cover: int = LANDSAT_MAX_CLOUD_COVER_PERCENT, log_level: int = logging.DEBUG
 ) -> bool:
     """Determines whether a scene is a valid Landsat product for processing.
 
@@ -77,8 +78,8 @@ def qualifies_for_landsat_processing(
 
 def get_landsat_pairs_for_reference_scene(
     reference: pystac.item.Item,
-    max_pair_separation: timedelta = timedelta(days=MAX_PAIR_SEPARATION_IN_DAYS),
-    max_cloud_cover: int = MAX_CLOUD_COVER_PERCENT,
+    max_pair_separation: timedelta = timedelta(days=LANDSAT_MAX_PAIR_SEPARATION_IN_DAYS),
+    max_cloud_cover: int = LANDSAT_MAX_CLOUD_COVER_PERCENT,
 ) -> gpd.GeoDataFrame:
     """Generate potential ITS_LIVE velocity pairs for a given Landsat scene.
 

--- a/its_live_monitoring/src/main.py
+++ b/its_live_monitoring/src/main.py
@@ -5,13 +5,11 @@ import json
 import logging
 import os
 import sys
-from datetime import timedelta
 
 import geopandas as gpd
 import hyp3_sdk as sdk
 import pandas as pd
 
-from constants import MAX_CLOUD_COVER_PERCENT, MAX_PAIR_SEPARATION_IN_DAYS, MIN_DATA_COVER_PERCENT
 from landsat import (
     get_landsat_pairs_for_reference_scene,
     get_landsat_stac_item,
@@ -88,21 +86,12 @@ def submit_pairs_for_processing(pairs: gpd.GeoDataFrame) -> sdk.Batch:  # noqa: 
 
 def process_scene(
     scene: str,
-    max_pair_separation: timedelta = timedelta(days=MAX_PAIR_SEPARATION_IN_DAYS),
-    max_cloud_cover: int = MAX_CLOUD_COVER_PERCENT,
-    min_data_cover: int = MIN_DATA_COVER_PERCENT,
-    s2_tile_path: str = None,
     submit: bool = True,
 ) -> sdk.Batch:
     """Trigger Landsat processing for a scene.
 
     Args:
         scene: Reference Landsat scene name to build pairs for.
-        max_pair_separation: How many days back from a reference scene's acquisition date to search for secondary
-         scenes.
-        max_cloud_cover: The maximum percent a Landsat scene can be covered by clouds.
-        min_data_cover: The minimum percent of data coverage of the sentinel-2 scene
-        s2_tile_path: The path for the tile of the sentinel2 scene.
         submit: Submit pairs to HyP3 for processing.
 
     Returns:
@@ -110,17 +99,18 @@ def process_scene(
     """
     pairs = None
     if scene.startswith('S2'):
-        reference = get_sentinel2_stac_item(f'{scene}.SAFE')
-        if qualifies_for_sentinel2_processing(reference, s2_tile_path, max_cloud_cover, min_data_cover, logging.INFO):
+        # Fixme: will throw if wrong collection!
+        reference = get_sentinel2_stac_item(scene)
+        if qualifies_for_sentinel2_processing(reference, logging.INFO):
             # hyp3-its-live will pull scenes from Google Cloud; ensure the new scene is there before processing
             # Note: Time between attempts is controlled by they SQS VisibilityTimout
             _ = raise_for_missing_in_google_cloud(scene)
-            pairs = get_sentinel2_pairs_for_reference_scene(reference, max_pair_separation, max_cloud_cover)
+            pairs = get_sentinel2_pairs_for_reference_scene(reference)
 
     else:
         reference = get_landsat_stac_item(scene)
-        if qualifies_for_landsat_processing(reference, max_cloud_cover, logging.INFO):
-            pairs = get_landsat_pairs_for_reference_scene(reference, max_pair_separation, max_cloud_cover)
+        if qualifies_for_landsat_processing(reference, logging.INFO):
+            pairs = get_landsat_pairs_for_reference_scene(reference)
 
     if pairs is None:
         return sdk.Batch()
@@ -162,12 +152,7 @@ def lambda_handler(event: dict, context: object) -> dict:
             body = json.loads(record['body'])
             message = json.loads(body['Message'])
             product_id = 'landsat_product_id' if 'landsat_product_id' in message.keys() else 'name'
-
-            s2_tile_path = None
-            if message[product_id].startswith('S2'):
-                s2_tile_path = message['tiles'][0]['path']
-
-            _ = process_scene(message[product_id], s2_tile_path=s2_tile_path)
+            _ = process_scene(message[product_id])
         except Exception:
             log.exception(f'Could not process message {record["messageId"]}')
             batch_item_failures.append({'itemIdentifier': record['messageId']})
@@ -178,18 +163,6 @@ def main() -> None:
     """Command Line wrapper around `process_scene`."""
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('reference', help='Reference Landsat scene name to build pairs for')
-    parser.add_argument(
-        '--max-pair-separation',
-        type=int,
-        default=MAX_PAIR_SEPARATION_IN_DAYS,
-        help="How many days back from a reference scene's acquisition date to search for secondary scenes",
-    )
-    parser.add_argument(
-        '--max-cloud-cover',
-        type=int,
-        default=MAX_CLOUD_COVER_PERCENT,
-        help='The maximum percent a Landsat scene can be covered by clouds',
-    )
     parser.add_argument('--submit', action='store_true', help='Submit pairs to HyP3 for processing')
     parser.add_argument('-v', '--verbose', action='store_true', help='Turn on verbose logging')
     args = parser.parse_args()
@@ -199,7 +172,7 @@ def main() -> None:
         log.setLevel(logging.DEBUG)
 
     log.debug(' '.join(sys.argv))
-    _ = process_scene(args.reference, timedelta(days=args.max_pair_separation), args.max_cloud_cover, args.submit)
+    _ = process_scene(args.reference, submit=args.submit)
 
 
 if __name__ == '__main__':

--- a/its_live_monitoring/src/sentinel2.py
+++ b/its_live_monitoring/src/sentinel2.py
@@ -78,7 +78,6 @@ def qualifies_for_sentinel2_processing(
     Returns:
         A bool that is True if the scene qualifies for Sentinel-2 processing, else False.
     """
-
     if item.collection_id != SENTINEL2_COLLECTION_NAME:
         log.log(log_level, f'{item.id} disqualifies for processing because it is from the wrong collection')
         return False

--- a/its_live_monitoring/src/sentinel2.py
+++ b/its_live_monitoring/src/sentinel2.py
@@ -11,16 +11,18 @@ import pandas as pd
 import pystac
 import pystac_client
 import requests
-from shapely.geometry import shape
-
-from constants import MAX_CLOUD_COVER_PERCENT, MAX_PAIR_SEPARATION_IN_DAYS, MIN_DATA_COVER_PERCENT
 
 
-SENTINEL2_CATALOG_API = 'https://catalogue.dataspace.copernicus.eu/stac'
+SENTINEL2_CATALOG_API = 'https://earth-search.aws.element84.com/v1/'
 SENTINEL2_CATALOG = pystac_client.Client.open(SENTINEL2_CATALOG_API)
-SENTINEL2_COLLECTION_NAME = 'SENTINEL-2'
+SENTINEL2_COLLECTION_NAME = 'sentinel-2-l1c'
 SENTINEL2_COLLECTION = SENTINEL2_CATALOG.get_collection(SENTINEL2_COLLECTION_NAME)
 SENTINEL2_TILES_TO_PROCESS = json.loads((Path(__file__).parent / 'sentinel2_tiles_to_process.json').read_text())
+
+SENTINEL2_MAX_PAIR_SEPARATION_IN_DAYS = 544
+SENTINEL2_MIN_PAIR_SEPARATION_IN_DAYS = 5
+SENTINEL2_MAX_CLOUD_COVER_PERCENT = 70
+SENTINEL2_MIN_DATA_COVERAGE = 70
 
 log = logging.getLogger('its_live_monitoring')
 log.setLevel(os.environ.get('LOGGING_LEVEL', 'INFO'))
@@ -35,39 +37,43 @@ def raise_for_missing_in_google_cloud(scene_name: str) -> None:  # noqa: D103
     response.raise_for_status()
 
 
-def get_sentinel2_stac_item(scene: str) -> pystac.Item:  # noqa: D103
-    item = SENTINEL2_COLLECTION.get_item(scene)
-    if item is None:
-        raise ValueError(
-            f'Scene {scene} not found in Sentinel-2 STAC collection: '
-            f'{SENTINEL2_CATALOG_API}/collections/{SENTINEL2_COLLECTION_NAME}'
-        )
+def add_data_coverage_to_item(item: pystac.Item) -> pystac.Item:  # noqa: D103
+    tile_info_path = item.assets['tileinfo_metadata'].href.rstrip('s3://')
+
+    response = requests.get(f'https://roda.sentinel-hub.com/{tile_info_path}')
+    response.raise_for_status()
+
+    item.properties['s2:data_coverage'] = response.json()['dataCoveragePercentage']
     return item
 
 
-def _get_data_coverage(s2_tile_path: str) -> float:
-    url = f'https://roda.sentinel-hub.com/sentinel-s2-l1c/{s2_tile_path}/tileInfo.json'
+def get_sentinel2_stac_item(scene: str) -> pystac.Item:  # noqa: D103
+    results = SENTINEL2_CATALOG.search(collections=[SENTINEL2_COLLECTION_NAME], query=[f's2:product_uri={scene}.SAFE'])
 
-    response = requests.get(url)
-    if response.status_code != 200:
-        return None
-    else:
-        return response.json()
+    items = [item for page in results.pages() for item in page]
+
+    if (n_items := len(items)) != 1:
+        raise ValueError(
+            f'{n_items} for {scene} found in Sentinel-2 STAC collection: '
+            f'{SENTINEL2_CATALOG_API}/collections/{SENTINEL2_COLLECTION_NAME}'
+        )
+
+    item = items[0]
+    item = add_data_coverage_to_item(item)
+
+    return item
 
 
 def qualifies_for_sentinel2_processing(
-        item: pystac.item.Item, s2_tile_path: str = None,
-        max_cloud_cover: int = MAX_CLOUD_COVER_PERCENT,
-        min_data_cover: int = MIN_DATA_COVER_PERCENT,
-        log_level: int = logging.DEBUG,
+    item: pystac.Item,
+    max_cloud_cover: int = SENTINEL2_MAX_CLOUD_COVER_PERCENT,
+    log_level: int = logging.DEBUG,
 ) -> bool:
     """Determines whether a scene is a valid Sentinel-2 product for processing.
 
     Args:
         item: STAC item of the desired Sentinel-2 scene.
-        s2_tile_path: The path of the tile of sentinel-2 scene.
         max_cloud_cover: The maximum allowable percentage of cloud cover.
-        min_data_cover: The minimum allowable percentage of data cover.
         log_level: The logging level
 
     Returns:
@@ -77,7 +83,7 @@ def qualifies_for_sentinel2_processing(
         log.log(log_level, f'{item.id} disqualifies for processing because it is from the wrong collection')
         return False
 
-    if item.id.split('_')[3] == 'N0500':
+    if item.properties['s2:product_uri'].split('_')[3] == 'N0500':
         # Reprocessing activity: https://sentinels.copernicus.eu/web/sentinel/technical-guides/sentinel-2-msi/copernicus-sentinel-2-collection-1-availability-status
         # Naming convention: https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-2-msi/naming-convention
         # Processing baselines: https://sentinels.copernicus.eu/web/sentinel/technical-guides/sentinel-2-msi/processing-baseline
@@ -88,11 +94,12 @@ def qualifies_for_sentinel2_processing(
         )
         return False
 
-    if not item.properties['productType'].endswith('1C'):
+    product_type = item.properties['s2:product_uri'].split('_')[3]
+    if not product_type.endswith('L1C'):
         log.log(log_level, f'{item.id} disqualifies for processing because it is the wrong product type.')
         return False
 
-    if item.properties['instrumentShortName'] != 'MSI':
+    if not product_type.startswith('MSI'):
         log.log(log_level, f'{item.id} disqualifies for processing because it was not imaged with the right instrument')
         return False
 
@@ -108,56 +115,42 @@ def qualifies_for_sentinel2_processing(
         log.log(log_level, f'{item.id} disqualifies for processing because it has too much cloud cover')
         return False
 
-    if s2_tile_path:
-        data_cover_percentage = _get_data_coverage(s2_tile_path)
-        if data_cover_percentage is None or data_cover_percentage <= min_data_cover:
-            log.log(log_level, f'{item.id} disqualifies for processing because its data coverage is too small')
-        return False
-
     log.log(log_level, f'{item.id} qualifies for processing')
     return True
 
 
 def get_sentinel2_pairs_for_reference_scene(
-    reference: pystac.item.Item,
-    max_pair_separation: timedelta = timedelta(days=MAX_PAIR_SEPARATION_IN_DAYS),
-    max_cloud_cover: int = MAX_CLOUD_COVER_PERCENT,
+    reference: pystac.Item,
+    max_pair_separation: timedelta = timedelta(days=SENTINEL2_MAX_PAIR_SEPARATION_IN_DAYS),
+    min_pair_separation: timedelta = timedelta(days=SENTINEL2_MIN_PAIR_SEPARATION_IN_DAYS),
+    max_cloud_cover: int = SENTINEL2_MAX_CLOUD_COVER_PERCENT,
 ) -> gpd.GeoDataFrame:
     """Generate potential ITS_LIVE velocity pairs for a given Sentinel-2 scene.
 
     Args:
-        reference: STAC item of the Sentinel-2 reference scene to find pairs for
-        max_pair_separation: How many days back from a reference scene's acquisition date to search for secondary scenes
+        reference: STAC item of the Sentinel-2 reference scene to find secondary scenes for
+        max_pair_separation: How many days back from a reference scene's acquisition date to start searching for
+            secondary scenes
+        min_pair_separation: How many days back from a reference scene's acquisition date to stop searching for
+            secondary scenes
         max_cloud_cover: The maximum percent of the secondary scene that can be covered by clouds
 
     Returns:
         A DataFrame with all potential pairs for a sentinel-2 reference scene. Metadata in the columns will be for the
         *secondary* scene unless specified otherwise.
     """
-    # Sentinel-2 tiles overlap by 10 km, so searching by bbox or geometry, will pull in results from multiple tiles.
-    # Since tiles are all 110 km in their UTM zone, they will be at least 1 deg x 1 deg in lat lon.
-    # Thus, drawing a 0.25 degree square around a tile centroid should limit the search to a single tile.
-    search_bbox = shape(reference.geometry).centroid.buffer(0.25, cap_style='square').bounds
-
     results = SENTINEL2_CATALOG.search(
         collections=[reference.collection_id],
-        bbox=search_bbox,
-        datetime=[reference.datetime - max_pair_separation, reference.datetime - timedelta(seconds=1)],
-        limit=1000,
-        method='GET',
+        query=[
+            f'grid:code={reference.properties["grid:code"]}',
+            f'eo:cloud_cover<={SENTINEL2_MAX_CLOUD_COVER_PERCENT}',
+        ],
+        datetime=[reference.datetime - max_pair_separation, reference.datetime - min_pair_separation],
     )
 
-    items = []
-    for page in results.pages():
-        for item in page:
-            if item.properties['tileId'] != reference.properties['tileId']:
-                log.debug(f'{item.id} disqualifies because it is from a different tile than the reference scene')
-                continue
-
-            if not qualifies_for_sentinel2_processing(item, max_cloud_cover=max_cloud_cover):
-                continue
-
-            items.append(item)
+    items = [
+        item for page in results.pages() for item in page if qualifies_for_sentinel2_processing(item, max_cloud_cover)
+    ]
 
     log.debug(f'Found {len(items)} secondary scenes for {reference.id}')
     if len(items) == 0:
@@ -166,9 +159,9 @@ def get_sentinel2_pairs_for_reference_scene(
     features = []
     for item in items:
         feature = item.to_dict()
-        feature['properties']['reference'] = reference.id.rstrip('.SAFE')
+        feature['properties']['reference'] = reference.properties['s2:product_uri'].rstrip('.SAFE')
         feature['properties']['reference_acquisition'] = reference.datetime
-        feature['properties']['secondary'] = item.id.rstrip('.SAFE')
+        feature['properties']['secondary'] = item.properties['s2:product_uri'].rstrip('.SAFE')
         features.append(feature)
 
     df = gpd.GeoDataFrame.from_features(features)


### PR DESCRIPTION
Also:
* breaks the constants into mission-specific as the cloud coverage number is different between the missions, and S2 has some additional constants
* cuts over to using the earth-search v1 STAC API


TODOs, before merging to develop:

- [x] Address FIXME in code :point_down: 
- [x] add data coverage to every secondary scene STAC item when doing the pair search
- [ ] confirm pair STAC search is what we want
- [ ] probably other things I haven't thought of ... 