### PR TITLE
Fix `qualifies_for_sentinel2_processing` kwarg

### DIFF
--- a/its_live_monitoring/src/landsat.py
+++ b/its_live_monitoring/src/landsat.py
@@ -36,7 +36,7 @@ def get_landsat_stac_item(scene: str) -> pystac.Item:  # noqa: D103
 
 
 def qualifies_for_landsat_processing(
-    item: pystac.item.Item, max_cloud_cover: int = LANDSAT_MAX_CLOUD_COVER_PERCENT, log_level: int = logging.DEBUG
+    item: pystac.item.Item, *, max_cloud_cover: int = LANDSAT_MAX_CLOUD_COVER_PERCENT, log_level: int = logging.DEBUG
 ) -> bool:
     """Determines whether a scene is a valid Landsat product for processing.
 
@@ -78,6 +78,7 @@ def qualifies_for_landsat_processing(
 
 def get_landsat_pairs_for_reference_scene(
     reference: pystac.item.Item,
+    *,
     max_pair_separation: timedelta = timedelta(days=LANDSAT_MAX_PAIR_SEPARATION_IN_DAYS),
     max_cloud_cover: int = LANDSAT_MAX_CLOUD_COVER_PERCENT,
 ) -> gpd.GeoDataFrame:
@@ -103,7 +104,10 @@ def get_landsat_pairs_for_reference_scene(
     )
 
     items = [
-        item for page in results.pages() for item in page if qualifies_for_landsat_processing(item, max_cloud_cover)
+        item
+        for page in results.pages()
+        for item in page
+        if qualifies_for_landsat_processing(item, max_cloud_cover=max_cloud_cover)
     ]
 
     log.debug(f'Found {len(items)} secondary scenes for {reference.id}')

--- a/its_live_monitoring/src/main.py
+++ b/its_live_monitoring/src/main.py
@@ -100,7 +100,7 @@ def process_scene(
     pairs = None
     if scene.startswith('S2'):
         reference = get_sentinel2_stac_item(scene)
-        if qualifies_for_sentinel2_processing(reference, logging.INFO):
+        if qualifies_for_sentinel2_processing(reference, log_level=logging.INFO):
             # hyp3-its-live will pull scenes from Google Cloud; ensure the new scene is there before processing
             # Note: Time between attempts is controlled by they SQS VisibilityTimout
             _ = raise_for_missing_in_google_cloud(scene)

--- a/its_live_monitoring/src/main.py
+++ b/its_live_monitoring/src/main.py
@@ -108,7 +108,7 @@ def process_scene(
 
     else:
         reference = get_landsat_stac_item(scene)
-        if qualifies_for_landsat_processing(reference, logging.INFO):
+        if qualifies_for_landsat_processing(reference, log_level=logging.INFO):
             pairs = get_landsat_pairs_for_reference_scene(reference)
 
     if pairs is None:

--- a/its_live_monitoring/src/sentinel2.py
+++ b/its_live_monitoring/src/sentinel2.py
@@ -84,6 +84,7 @@ def get_sentinel2_stac_item(scene: str) -> pystac.Item:
 
 def qualifies_for_sentinel2_processing(
     item: pystac.Item,
+    *,
     max_cloud_cover: int = SENTINEL2_MAX_CLOUD_COVER_PERCENT,
     log_level: int = logging.DEBUG,
 ) -> bool:
@@ -144,6 +145,7 @@ def qualifies_for_sentinel2_processing(
 
 def get_sentinel2_pairs_for_reference_scene(
     reference: pystac.Item,
+    *,
     max_pair_separation: timedelta = timedelta(days=SENTINEL2_MAX_PAIR_SEPARATION_IN_DAYS),
     min_pair_separation: timedelta = timedelta(days=SENTINEL2_MIN_PAIR_SEPARATION_IN_DAYS),
     max_cloud_cover: int = SENTINEL2_MAX_CLOUD_COVER_PERCENT,
@@ -166,7 +168,7 @@ def get_sentinel2_pairs_for_reference_scene(
         collections=[reference.collection_id],
         query=[
             f'grid:code={reference.properties["grid:code"]}',
-            f'eo:cloud_cover<={SENTINEL2_MAX_CLOUD_COVER_PERCENT}',
+            f'eo:cloud_cover<={max_cloud_cover}',
         ],
         datetime=[reference.datetime - max_pair_separation, reference.datetime - min_pair_separation],
     )

--- a/its_live_monitoring/src/sentinel2.py
+++ b/its_live_monitoring/src/sentinel2.py
@@ -172,7 +172,9 @@ def get_sentinel2_pairs_for_reference_scene(
     )
 
     items = [
-        item for page in results.pages() for item in page
+        item
+        for page in results.pages()
+        for item in page
         if qualifies_for_sentinel2_processing(item, max_cloud_cover=max_cloud_cover)
     ]
 

--- a/its_live_monitoring/src/sentinel2.py
+++ b/its_live_monitoring/src/sentinel2.py
@@ -172,7 +172,8 @@ def get_sentinel2_pairs_for_reference_scene(
     )
 
     items = [
-        item for page in results.pages() for item in page if qualifies_for_sentinel2_processing(item, max_cloud_cover)
+        item for page in results.pages() for item in page
+        if qualifies_for_sentinel2_processing(item, max_cloud_cover=max_cloud_cover)
     ]
 
     log.debug(f'Found {len(items)} secondary scenes for {reference.id}')


### PR DESCRIPTION
The `qualifies_for_sentinel2_processing` function is defined [here](https://github.com/ASFHyP3/its-live-monitoring/blob/develop/its_live_monitoring/src/sentinel2.py#L85). In `its_live_monitoring/src/main.py` we call that function and pass `logging.INFO` for the `max_cloud_cover` parameter. I've added keyword arguments for the two calls to this function to fix that bug and avoid future confusion.