### PR TITLE
Disqualify secondary scene if relative orbit does not match that of reference scene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.2]
 
-### Added
-- Sentinel-2 products will now be disqualified from processing if they do not have enough data coverage.
 ### Changed
-- Switched from Dataspace's Sentinel-2 STAC API to Element84's
+- Sentinel-2 products are now disqualified from processing if they do not have enough data coverage.
+- Sentinel-2 products are now disqualified from processing if the secondary scene's relative orbit does not match that of the reference scene.
+- Switched from Dataspace's Sentinel-2 STAC API to Element84's.
 
 ## [0.5.1]
 

--- a/its_live_monitoring/src/main.py
+++ b/its_live_monitoring/src/main.py
@@ -100,7 +100,7 @@ def process_scene(
     pairs = None
     if scene.startswith('S2'):
         reference = get_sentinel2_stac_item(scene)
-        if qualifies_for_sentinel2_processing(reference, logging.INFO):
+        if qualifies_for_sentinel2_processing(reference, log_level=logging.INFO):
             # hyp3-its-live will pull scenes from Google Cloud; ensure the new scene is there before processing
             # Note: Time between attempts is controlled by they SQS VisibilityTimout
             _ = raise_for_missing_in_google_cloud(scene)

--- a/its_live_monitoring/src/sentinel2.py
+++ b/its_live_monitoring/src/sentinel2.py
@@ -56,7 +56,12 @@ def get_data_coverage_for_item(item: pystac.Item) -> float:
     tile_info_path = item.assets['tileinfo_metadata'].href[5:]
 
     response = requests.get(f'https://roda.sentinel-hub.com/{tile_info_path}')
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as e:
+        # TODO: what to do in this case?
+        print(e)
+        return 0
     data_coverage = response.json()['dataCoveragePercentage']
 
     return data_coverage

--- a/its_live_monitoring/src/sentinel2.py
+++ b/its_live_monitoring/src/sentinel2.py
@@ -99,7 +99,7 @@ def qualifies_for_sentinel2_processing(
 
     Args:
         item: STAC item of the desired Sentinel-2 scene.
-        reference: STAC item of the Sentinel-2 reference scene.
+        reference: STAC item of the Sentinel-2 reference scene for optional relative orbit comparison.
         max_cloud_cover: The maximum allowable percentage of cloud cover.
         log_level: The logging level
 

--- a/its_live_monitoring/src/sentinel2.py
+++ b/its_live_monitoring/src/sentinel2.py
@@ -114,6 +114,7 @@ def qualifies_for_sentinel2_processing(
                 f'{item.id} disqualifies for processing because its relative orbit ({item_relative_orbit}) '
                 f'does not match that of the reference scene ({reference_relative_orbit})'
             )
+            return False
 
     if item.collection_id != SENTINEL2_COLLECTION_NAME:
         log.log(log_level, f'{item.id} disqualifies for processing because it is from the wrong collection')

--- a/its_live_monitoring/src/sentinel2.py
+++ b/its_live_monitoring/src/sentinel2.py
@@ -112,7 +112,7 @@ def qualifies_for_sentinel2_processing(
             log.log(
                 log_level,
                 f'{item.id} disqualifies for processing because its relative orbit ({item_relative_orbit}) '
-                f'does not match that of the reference scene ({reference_relative_orbit})'
+                f'does not match that of the reference scene ({reference_relative_orbit})',
             )
             return False
 

--- a/its_live_monitoring/src/sentinel2.py
+++ b/its_live_monitoring/src/sentinel2.py
@@ -172,7 +172,9 @@ def get_sentinel2_pairs_for_reference_scene(
     )
 
     items = [
-        item for page in results.pages() for item in page
+        item
+        for page in results.pages()
+        for item in page
         if qualifies_for_sentinel2_processing(item, max_cloud_cover=max_cloud_cover)
     ]
 

--- a/its_live_monitoring/src/sentinel2.py
+++ b/its_live_monitoring/src/sentinel2.py
@@ -172,7 +172,8 @@ def get_sentinel2_pairs_for_reference_scene(
     )
 
     items = [
-        item for page in results.pages() for item in page if qualifies_for_sentinel2_processing(item, max_cloud_cover)
+        item for page in results.pages() for item in page
+        if qualifies_for_sentinel2_processing(item, max_cloud_cover=max_cloud_cover)
     ]
 
     log.debug(f'Found {len(items)} secondary scenes for {reference.id}')


### PR DESCRIPTION
Implements @AndrewPlayer3's proposed solution. Without these changes, the command:

```
python its_live_monitoring/src/main.py S2B_MSIL1C_20220914T162839_N0400_R083_T28XEQ_20220914T183321 -v
```

found 404 secondary scenes that qualify for processing. After these changes, it found 26 scenes (which is close to @AndrewPlayer3's estimated prediction of 28).

TODO:

- [x] Merge https://github.com/ASFHyP3/its-live-monitoring/pull/98
- [x] `TODO`s in code
- [x] Add/update tests
- [x] Changelog