### PR TITLE
pin packages in requirements-all.txt

### DIFF
--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -1,6 +1,6 @@
 -r requirements-its_live_monitoring.txt
 -r requirements-status-messages.txt
-cfn-lint
-ruff
-pytest
-responses
+cfn-lint==0.87.8
+ruff==0.4.10
+pytest==8.2.2
+responses==0.25.3


### PR DESCRIPTION
Pins `cfn-lint` to the previous release because of an apparent bug which is causing failing checks such as [this one](https://github.com/ASFHyP3/its-live-monitoring/actions/runs/9588501881/job/26440660039?pr=96), and pins the other packages to their latest releases.